### PR TITLE
make <space> usage clearer

### DIFF
--- a/minesweeper
+++ b/minesweeper
@@ -163,7 +163,7 @@ def main():
     Initialization of game and main event loop.
     """
     parser = argparse.ArgumentParser(
-        description="Play a game of minesweeper. Use arrows to move, 'enter' to probe, 'f' to flag, CTRL-C to exit."
+        description="Play a game of minesweeper. Use arrows to move, 'enter' or 'space' to probe, 'f' to flag, CTRL-C to exit."
     )
     parser.add_argument(
         '--height',
@@ -197,7 +197,7 @@ def main():
         if keyid:
             if keyid in msweep.inpt.ARROW_KEYS:
                 move_select(keyid, board)
-            if keyid == msweep.inpt.KEY_ENTER:
+            if keyid in msweep.inpt.PROBE_KEYS:
                 probe(board)
         elif key['bytes'] == ['f']:
             flag(board)

--- a/msweep/inpt.py
+++ b/msweep/inpt.py
@@ -51,6 +51,7 @@ KEY_UP = iota()
 KEY_LEFT = iota()
 KEY_RIGHT = iota()
 KEY_ENTER = iota()
+KEY_SPACE = iota()
 
 # These are the control keys
 _KEYMAP = {
@@ -64,8 +65,7 @@ _KEYMAP = {
             'C': KEY_RIGHT
         }
     },
-    # Space is also enter
-    ' ' : KEY_ENTER,
+    ' ' : KEY_SPACE,
     # vim keys
     'k': KEY_UP,
     'j': KEY_DOWN,
@@ -79,6 +79,7 @@ _KEYMAP = {
 }
 
 ARROW_KEYS = set([KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT])
+PROBE_KEYS = set([KEY_ENTER, KEY_SPACE])
 
 
 def keymap(buf):


### PR DESCRIPTION
I changed the keyboard parsing to be more consistent with arrow-key checking syntax, and made it clear in the help message that <space> and <enter> can be used to probe a cell
